### PR TITLE
Add Start Walk and Start Run complications for Apple Watch

### DIFF
--- a/StepSync.xcodeproj/project.pbxproj
+++ b/StepSync.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		1A3B547353FD79EBE8BF6240 /* InsightsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18A93CE6EB05FAF1E990446 /* InsightsView.swift */; };
 		1D1B073A83B61226FA80B02F /* WorkoutRoutePoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8466F800DC5F4FA3F9B3D814 /* WorkoutRoutePoint.swift */; };
 		1DEF5897BADD1DAB17E65027 /* StepSyncWatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619EB00206311DE7D8DBD4A2 /* StepSyncWatchApp.swift */; };
+		B5C6D7E8F90A4B526D7E8F90 /* QuickStartState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D6E7F8A90B5C637E8F9A01 /* QuickStartState.swift */; };
 		22915DDAC7B7C1814DE05D39 /* WorkoutMirroringManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18FA06FB36ADE1392E8D0ED1 /* WorkoutMirroringManager.swift */; };
 		233B3E958796B2A6FEBF89C3 /* StepCountService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36DE2B023C269886C0C72B02 /* StepCountService.swift */; };
 		2A72240B360DF520BC7A2416 /* HeartRateSample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32301399A96F7071922FB9FD /* HeartRateSample.swift */; };
@@ -39,6 +40,10 @@
 		4C3049779EFE5BB11DF9D9AB /* DailyStepRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4617766756B3D1838B005EF6 /* DailyStepRecord.swift */; };
 		4C59FD25079323B0884E0645 /* Streak.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED2D5FFE494B543573B7067 /* Streak.swift */; };
 		4F064DD86EFE427B8FE2C887 /* WorkoutComplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D7D9551DF692D50A88ADA1 /* WorkoutComplication.swift */; };
+		A1B2C3D4E5F60718293A4B5C /* WatchWorkoutIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E2F3A4B5C60718293A4B5C /* WatchWorkoutIntents.swift */; };
+		A2B3C4D5E6F70829304B5C6D /* StartWalkComplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E3F4A5B6C70829304B5C6D /* StartWalkComplication.swift */; };
+		A3B4C5D6E7F8093A415C6D7E /* StartRunComplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E4F5A6B7C8093A415C6D7E /* StartRunComplication.swift */; };
+		A4B5C6D7E8F90A4B526D7E8F /* QuickStartEnvironmentPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5F6A7B8C90A4B526D7E8F /* QuickStartEnvironmentPicker.swift */; };
 		4FEDE9F71D3ABCCB62CA579F /* Achievement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DBC5600BC8DB848DC91356 /* Achievement.swift */; };
 		505BC8E1304D35F2B2105FF2 /* DailyStepRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4617766756B3D1838B005EF6 /* DailyStepRecord.swift */; };
 		527DB067461BE4C9ACB72BC9 /* WatchDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72BF69FC65C1525C3C8307DD /* WatchDashboardView.swift */; };
@@ -191,6 +196,7 @@
 		548AD23161466182141BC9A7 /* WorkoutSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutSessionManager.swift; sourceTree = "<group>"; };
 		56BEDFEBA6DD47063E808711 /* StepSync.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StepSync.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		619EB00206311DE7D8DBD4A2 /* StepSyncWatchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepSyncWatchApp.swift; sourceTree = "<group>"; };
+		C5D6E7F8A90B5C637E8F9A01 /* QuickStartState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartState.swift; sourceTree = "<group>"; };
 		64F48F4938DC62F2A41DDCBA /* StepSyncWatchWidgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepSyncWatchWidgets.swift; sourceTree = "<group>"; };
 		69EE6E1BC1242D763230E423 /* QuickStartWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartWidget.swift; sourceTree = "<group>"; };
 		6A159FACE8486A808DC22982 /* InsightsCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightsCalculator.swift; sourceTree = "<group>"; };
@@ -201,6 +207,10 @@
 		83F941819B3BFC81F28DDC46 /* CompanionMetricCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionMetricCard.swift; sourceTree = "<group>"; };
 		8466F800DC5F4FA3F9B3D814 /* WorkoutRoutePoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutRoutePoint.swift; sourceTree = "<group>"; };
 		84D7D9551DF692D50A88ADA1 /* WorkoutComplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutComplication.swift; sourceTree = "<group>"; };
+		D1E2F3A4B5C60718293A4B5C /* WatchWorkoutIntents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchWorkoutIntents.swift; sourceTree = "<group>"; };
+		D2E3F4A5B6C70829304B5C6D /* StartWalkComplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartWalkComplication.swift; sourceTree = "<group>"; };
+		D3E4F5A6B7C8093A415C6D7E /* StartRunComplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartRunComplication.swift; sourceTree = "<group>"; };
+		D4E5F6A7B8C90A4B526D7E8F /* QuickStartEnvironmentPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartEnvironmentPicker.swift; sourceTree = "<group>"; };
 		85181D750B2E1710D8284CF9 /* WorkoutLiveActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutLiveActivityView.swift; sourceTree = "<group>"; };
 		8672D93AEF6BB62A817B56A2 /* UserSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettings.swift; sourceTree = "<group>"; };
 		8C2E7BFC21DC3DDC2210F50E /* StepSyncIntents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepSyncIntents.swift; sourceTree = "<group>"; };
@@ -362,6 +372,7 @@
 		7558C0689C49B3D45DE88B3F /* App */ = {
 			isa = PBXGroup;
 			children = (
+				C5D6E7F8A90B5C637E8F9A01 /* QuickStartState.swift */,
 				619EB00206311DE7D8DBD4A2 /* StepSyncWatchApp.swift */,
 				B42EE5022974865C949AE556 /* WatchContentView.swift */,
 			);
@@ -371,6 +382,7 @@
 		8094E78AD83574A6ABABFBBD /* Workouts */ = {
 			isa = PBXGroup;
 			children = (
+				D4E5F6A7B8C90A4B526D7E8F /* QuickStartEnvironmentPicker.swift */,
 				8CA7ED7B84E9BAF769CB5094 /* WatchWorkoutView.swift */,
 			);
 			path = Workouts;
@@ -474,8 +486,11 @@
 			isa = PBXGroup;
 			children = (
 				64F48F4938DC62F2A41DDCBA /* StepSyncWatchWidgets.swift */,
+				D1E2F3A4B5C60718293A4B5C /* WatchWorkoutIntents.swift */,
 				A842F3F475E3A6187DA5F66B /* StepCountComplication */,
 				F159198D8948F9F6FC2FFBC7 /* WorkoutComplication */,
+				B1C2D3E4F5A60718293A4B5C /* StartWalkComplication */,
+				B2C3D4E5F6A70829304B5C6D /* StartRunComplication */,
 			);
 			path = StepSyncWatchWidgets;
 			sourceTree = "<group>";
@@ -486,6 +501,22 @@
 				251834999B5DE6FF62E41CDC /* StepCountComplication.swift */,
 			);
 			path = StepCountComplication;
+			sourceTree = "<group>";
+		};
+		B1C2D3E4F5A60718293A4B5C /* StartWalkComplication */ = {
+			isa = PBXGroup;
+			children = (
+				D2E3F4A5B6C70829304B5C6D /* StartWalkComplication.swift */,
+			);
+			path = StartWalkComplication;
+			sourceTree = "<group>";
+		};
+		B2C3D4E5F6A70829304B5C6D /* StartRunComplication */ = {
+			isa = PBXGroup;
+			children = (
+				D3E4F5A6B7C8093A415C6D7E /* StartRunComplication.swift */,
+			);
+			path = StartRunComplication;
 			sourceTree = "<group>";
 		};
 		ACA9EF8BCCE83C50E8170338 /* StepSync */ = {
@@ -864,11 +895,14 @@
 				1078761F90D9E31DD5A5DF54 /* Achievement.swift in Sources */,
 				B4601F99E0F67BDE1FDB164D /* DailyStepRecord.swift in Sources */,
 				BF7F4F2B855F5D0F3B6B44A1 /* HeartRateSample.swift in Sources */,
+				A3B4C5D6E7F8093A415C6D7E /* StartRunComplication.swift in Sources */,
+				A2B3C4D5E6F70829304B5C6D /* StartWalkComplication.swift in Sources */,
 				3664A1D8ABA0DCC8D590E894 /* StepCountComplication.swift in Sources */,
 				58DAF42072F7F31E510F5EDF /* StepGoal.swift in Sources */,
 				2CA358120DB1981A17FCC256 /* StepSyncWatchWidgets.swift in Sources */,
 				6905F07069B0BA1E1725C06E /* Streak.swift in Sources */,
 				83CA375B50C1009DC24F32CE /* UserSettings.swift in Sources */,
+				A1B2C3D4E5F60718293A4B5C /* WatchWorkoutIntents.swift in Sources */,
 				E46E1647FA941BEB75FB6C36 /* Workout.swift in Sources */,
 				920BD90A138AE08CCF8E239E /* WorkoutActivityAttributes.swift in Sources */,
 				4F064DD86EFE427B8FE2C887 /* WorkoutComplication.swift in Sources */,
@@ -952,6 +986,8 @@
 				39A3FCA4096763DF795A1433 /* WatchConnectivityManager.swift in Sources */,
 				04F5DD65BC5CAB8BF05C1729 /* WatchContentView.swift in Sources */,
 				527DB067461BE4C9ACB72BC9 /* WatchDashboardView.swift in Sources */,
+				B5C6D7E8F90A4B526D7E8F90 /* QuickStartState.swift in Sources */,
+				A4B5C6D7E8F90A4B526D7E8F /* QuickStartEnvironmentPicker.swift in Sources */,
 				B6D6FA2F6CE16B476848186E /* WatchSummaryView.swift in Sources */,
 				70CBB78301B05480D653CECC /* WatchWorkoutView.swift in Sources */,
 				F12B078195B469600F2DD150 /* Workout.swift in Sources */,

--- a/StepSync.xcodeproj/watchOS-Info.plist
+++ b/StepSync.xcodeproj/watchOS-Info.plist
@@ -24,6 +24,17 @@
 	</array>
 	<key>WKWatchOnly</key>
 	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.nwwsolutions.stepsync.watch</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>stepsync</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSHealthShareUsageDescription</key>
 	<string>StepSync needs access to your health data to track your steps and fitness progress.</string>
 	<key>NSHealthUpdateUsageDescription</key>

--- a/StepSyncWatch/App/QuickStartState.swift
+++ b/StepSyncWatch/App/QuickStartState.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+/// Shared state for managing quick start workout flow from complications
+@MainActor
+@Observable
+final class QuickStartState {
+    static let shared = QuickStartState()
+
+    var pendingWorkoutType: WorkoutType?
+    var showQuickStartPicker: Bool = false
+
+    private init() {}
+
+    /// Handles a deep link URL from a complication
+    /// - Parameter url: The URL to handle (e.g., stepsync://workout/start?type=walking)
+    /// - Returns: true if the URL was handled successfully
+    @discardableResult
+    func handleURL(_ url: URL) -> Bool {
+        print("QuickStartState: Handling URL: \(url)")
+
+        // Parse the URL
+        guard url.scheme == "stepsync",
+              url.host == "workout",
+              url.pathComponents.contains("start") else {
+            print("QuickStartState: Invalid URL format - scheme: \(url.scheme ?? "nil"), host: \(url.host ?? "nil"), path: \(url.pathComponents)")
+            return false
+        }
+
+        // Extract workout type from query parameters
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let typeParam = components.queryItems?.first(where: { $0.name == "type" })?.value,
+              let workoutType = WorkoutType(rawValue: typeParam) else {
+            print("QuickStartState: Could not parse workout type from URL")
+            return false
+        }
+
+        print("QuickStartState: Setting pending workout type to \(workoutType.displayName)")
+        pendingWorkoutType = workoutType
+        showQuickStartPicker = true
+        return true
+    }
+
+    /// Clears the pending workout state
+    func clear() {
+        pendingWorkoutType = nil
+        showQuickStartPicker = false
+    }
+}

--- a/StepSyncWatch/App/WatchContentView.swift
+++ b/StepSyncWatch/App/WatchContentView.swift
@@ -1,16 +1,71 @@
 import SwiftUI
+import SwiftData
 
 struct WatchContentView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(WorkoutSessionManager.self) private var sessionManager
+    @Environment(QuickStartState.self) private var quickStartState
+
+    @State private var currentWorkout: Workout?
+    @State private var selectedTab: Int = 0
+
     var body: some View {
+        @Bindable var quickStart = quickStartState
+
         NavigationStack {
-            TabView {
+            TabView(selection: $selectedTab) {
                 WatchDashboardView()
+                    .tag(0)
 
                 WatchWorkoutView()
+                    .tag(1)
 
                 WatchSummaryView()
+                    .tag(2)
             }
             .tabViewStyle(.verticalPage)
+        }
+        .fullScreenCover(isPresented: $quickStart.showQuickStartPicker) {
+            if let workoutType = quickStartState.pendingWorkoutType {
+                QuickStartEnvironmentPicker(
+                    workoutType: workoutType,
+                    onEnvironmentSelected: { environment in
+                        startWorkout(type: workoutType, environment: environment)
+                    },
+                    onCancel: {
+                        quickStartState.clear()
+                    }
+                )
+            }
+        }
+        .onChange(of: sessionManager.isSessionActive) { wasActive, isActive in
+            // Navigate back to dashboard when workout ends
+            if wasActive && !isActive {
+                selectedTab = 0
+            }
+        }
+    }
+
+    /// Starts a workout with the given type and environment
+    private func startWorkout(type: WorkoutType, environment: WorkoutEnvironment) {
+        quickStartState.clear()
+
+        Task {
+            do {
+                try await sessionManager.startWorkout(type: type, environment: environment)
+
+                await MainActor.run {
+                    let workout = Workout(type: type, environment: environment)
+                    modelContext.insert(workout)
+                    try? modelContext.save()
+                    currentWorkout = workout
+
+                    // Navigate to the workout tab to show the active workout
+                    selectedTab = 1
+                }
+            } catch {
+                print("Failed to start workout from complication: \(error)")
+            }
         }
     }
 }

--- a/StepSyncWatch/Features/Workouts/QuickStartEnvironmentPicker.swift
+++ b/StepSyncWatch/Features/Workouts/QuickStartEnvironmentPicker.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+import WatchKit
+
+/// A minimal picker view shown when the Watch app launches from a complication.
+/// Allows the user to quickly select indoor/outdoor environment before starting a workout.
+struct QuickStartEnvironmentPicker: View {
+    let workoutType: WorkoutType
+    let onEnvironmentSelected: (WorkoutEnvironment) -> Void
+    let onCancel: () -> Void
+
+    private var themeColor: Color {
+        workoutType == .running ? .orange : .green
+    }
+
+    private var workoutIcon: String {
+        workoutType == .running ? "figure.run" : "figure.walk"
+    }
+
+    private var workoutName: String {
+        workoutType == .running ? "Running" : "Walking"
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            // Header
+            HStack {
+                Image(systemName: workoutIcon)
+                    .foregroundStyle(themeColor)
+                Text("Start \(workoutName)")
+                    .font(.headline)
+            }
+
+            // Environment buttons
+            HStack(spacing: 12) {
+                environmentButton(environment: .outdoor)
+                environmentButton(environment: .indoor)
+            }
+
+            // Cancel button
+            Button("Cancel", role: .cancel) {
+                WKInterfaceDevice.current().play(.click)
+                onCancel()
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+        .padding()
+    }
+
+    private func environmentButton(environment: WorkoutEnvironment) -> some View {
+        Button {
+            WKInterfaceDevice.current().play(.start)
+            onEnvironmentSelected(environment)
+        } label: {
+            VStack(spacing: 6) {
+                Image(systemName: environment == .outdoor ? "sun.max.fill" : "building.2.fill")
+                    .font(.title2)
+                    .foregroundStyle(environment == .outdoor ? .yellow : .gray)
+
+                Text(environment.displayName)
+                    .font(.caption)
+                    .fontWeight(.medium)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background(themeColor.opacity(0.15))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(themeColor.opacity(0.3), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    QuickStartEnvironmentPicker(
+        workoutType: .walking,
+        onEnvironmentSelected: { _ in },
+        onCancel: {}
+    )
+}
+
+#Preview {
+    QuickStartEnvironmentPicker(
+        workoutType: .running,
+        onEnvironmentSelected: { _ in },
+        onCancel: {}
+    )
+}

--- a/StepSyncWatch/Resources/Info.plist
+++ b/StepSyncWatch/Resources/Info.plist
@@ -30,6 +30,17 @@
 	<true/>
 	<key>WKCompanionAppBundleIdentifier</key>
 	<string>com.nwwsolutions.stepsync</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.nwwsolutions.stepsync.watch</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>stepsync</string>
+			</array>
+		</dict>
+	</array>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>

--- a/StepSyncWatchWidgets/StartRunComplication/StartRunComplication.swift
+++ b/StepSyncWatchWidgets/StartRunComplication/StartRunComplication.swift
@@ -1,0 +1,127 @@
+import WidgetKit
+import SwiftUI
+
+struct StartRunEntry: TimelineEntry {
+    let date: Date
+}
+
+struct StartRunProvider: TimelineProvider {
+    func placeholder(in context: Context) -> StartRunEntry {
+        StartRunEntry(date: Date())
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (StartRunEntry) -> Void) {
+        completion(StartRunEntry(date: Date()))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<StartRunEntry>) -> Void) {
+        let entry = StartRunEntry(date: Date())
+        // Static complication, update once per day
+        let nextUpdate = Calendar.current.date(byAdding: .day, value: 1, to: Date()) ?? Date()
+        let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
+        completion(timeline)
+    }
+}
+
+struct StartRunComplication: Widget {
+    let kind: String = "StartRunComplication"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: StartRunProvider()) { entry in
+            StartRunComplicationView(entry: entry)
+        }
+        .configurationDisplayName("Start Run")
+        .description("Quickly start a running workout.")
+        .supportedFamilies([
+            .accessoryCircular,
+            .accessoryRectangular,
+            .accessoryInline,
+            .accessoryCorner
+        ])
+    }
+}
+
+struct StartRunComplicationView: View {
+    @Environment(\.widgetFamily) var family
+    let entry: StartRunEntry
+
+    /// Deep link URL to start a running workout
+    private let deepLinkURL = URL(string: "stepsync://workout/start?type=running")!
+
+    var body: some View {
+        Group {
+            switch family {
+            case .accessoryCircular:
+                circularView
+            case .accessoryRectangular:
+                rectangularView
+            case .accessoryInline:
+                inlineView
+            case .accessoryCorner:
+                cornerView
+            default:
+                circularView
+            }
+        }
+        .containerBackground(.fill.tertiary, for: .widget)
+        .widgetURL(deepLinkURL)
+    }
+
+    private var circularView: some View {
+        VStack(spacing: 2) {
+            Image(systemName: "figure.run")
+                .font(.title3)
+                .foregroundStyle(.orange)
+
+            Text("Run")
+                .font(.system(size: 10, weight: .medium))
+        }
+    }
+
+    private var rectangularView: some View {
+        HStack {
+            Image(systemName: "figure.run")
+                .font(.title2)
+                .foregroundStyle(.orange)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Start Run")
+                    .font(.headline)
+
+                Text("Tap to begin")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+        }
+    }
+
+    private var inlineView: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "figure.run")
+            Text("Start Run")
+        }
+    }
+
+    private var cornerView: some View {
+        Image(systemName: "figure.run")
+            .font(.title3)
+            .foregroundStyle(.orange)
+            .widgetLabel {
+                Text("Run")
+            }
+    }
+}
+
+#Preview(as: .accessoryCircular) {
+    StartRunComplication()
+} timeline: {
+    StartRunEntry(date: Date())
+}
+
+#Preview(as: .accessoryRectangular) {
+    StartRunComplication()
+} timeline: {
+    StartRunEntry(date: Date())
+}

--- a/StepSyncWatchWidgets/StartWalkComplication/StartWalkComplication.swift
+++ b/StepSyncWatchWidgets/StartWalkComplication/StartWalkComplication.swift
@@ -1,0 +1,127 @@
+import WidgetKit
+import SwiftUI
+
+struct StartWalkEntry: TimelineEntry {
+    let date: Date
+}
+
+struct StartWalkProvider: TimelineProvider {
+    func placeholder(in context: Context) -> StartWalkEntry {
+        StartWalkEntry(date: Date())
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (StartWalkEntry) -> Void) {
+        completion(StartWalkEntry(date: Date()))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<StartWalkEntry>) -> Void) {
+        let entry = StartWalkEntry(date: Date())
+        // Static complication, update once per day
+        let nextUpdate = Calendar.current.date(byAdding: .day, value: 1, to: Date()) ?? Date()
+        let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
+        completion(timeline)
+    }
+}
+
+struct StartWalkComplication: Widget {
+    let kind: String = "StartWalkComplication"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: StartWalkProvider()) { entry in
+            StartWalkComplicationView(entry: entry)
+        }
+        .configurationDisplayName("Start Walk")
+        .description("Quickly start a walking workout.")
+        .supportedFamilies([
+            .accessoryCircular,
+            .accessoryRectangular,
+            .accessoryInline,
+            .accessoryCorner
+        ])
+    }
+}
+
+struct StartWalkComplicationView: View {
+    @Environment(\.widgetFamily) var family
+    let entry: StartWalkEntry
+
+    /// Deep link URL to start a walking workout
+    private let deepLinkURL = URL(string: "stepsync://workout/start?type=walking")!
+
+    var body: some View {
+        Group {
+            switch family {
+            case .accessoryCircular:
+                circularView
+            case .accessoryRectangular:
+                rectangularView
+            case .accessoryInline:
+                inlineView
+            case .accessoryCorner:
+                cornerView
+            default:
+                circularView
+            }
+        }
+        .containerBackground(.fill.tertiary, for: .widget)
+        .widgetURL(deepLinkURL)
+    }
+
+    private var circularView: some View {
+        VStack(spacing: 2) {
+            Image(systemName: "figure.walk")
+                .font(.title3)
+                .foregroundStyle(.green)
+
+            Text("Walk")
+                .font(.system(size: 10, weight: .medium))
+        }
+    }
+
+    private var rectangularView: some View {
+        HStack {
+            Image(systemName: "figure.walk")
+                .font(.title2)
+                .foregroundStyle(.green)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Start Walk")
+                    .font(.headline)
+
+                Text("Tap to begin")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+        }
+    }
+
+    private var inlineView: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "figure.walk")
+            Text("Start Walk")
+        }
+    }
+
+    private var cornerView: some View {
+        Image(systemName: "figure.walk")
+            .font(.title3)
+            .foregroundStyle(.green)
+            .widgetLabel {
+                Text("Walk")
+            }
+    }
+}
+
+#Preview(as: .accessoryCircular) {
+    StartWalkComplication()
+} timeline: {
+    StartWalkEntry(date: Date())
+}
+
+#Preview(as: .accessoryRectangular) {
+    StartWalkComplication()
+} timeline: {
+    StartWalkEntry(date: Date())
+}

--- a/StepSyncWatchWidgets/StepSyncWatchWidgets.swift
+++ b/StepSyncWatchWidgets/StepSyncWatchWidgets.swift
@@ -6,5 +6,7 @@ struct StepSyncWatchWidgetBundle: WidgetBundle {
     var body: some Widget {
         StepCountComplication()
         WorkoutComplication()
+        StartWalkComplication()
+        StartRunComplication()
     }
 }

--- a/StepSyncWatchWidgets/WatchWorkoutIntents.swift
+++ b/StepSyncWatchWidgets/WatchWorkoutIntents.swift
@@ -1,0 +1,29 @@
+import AppIntents
+
+/// AppIntent for starting a walking workout from the Watch complication
+struct WatchStartWalkIntent: AppIntent {
+    static let title: LocalizedStringResource = "Start Walk"
+    static let description = IntentDescription("Start a walking workout from the Watch face")
+    static let openAppWhenRun: Bool = true
+
+    func perform() async throws -> some IntentResult {
+        let userDefaults = UserDefaults(suiteName: "group.com.nwwsolutions.steppingszn")
+        userDefaults?.set("walking", forKey: "pendingWatchWorkoutType")
+        userDefaults?.set(true, forKey: "showQuickStartPicker")
+        return .result()
+    }
+}
+
+/// AppIntent for starting a running workout from the Watch complication
+struct WatchStartRunIntent: AppIntent {
+    static let title: LocalizedStringResource = "Start Run"
+    static let description = IntentDescription("Start a running workout from the Watch face")
+    static let openAppWhenRun: Bool = true
+
+    func perform() async throws -> some IntentResult {
+        let userDefaults = UserDefaults(suiteName: "group.com.nwwsolutions.steppingszn")
+        userDefaults?.set("running", forKey: "pendingWatchWorkoutType")
+        userDefaults?.set(true, forKey: "showQuickStartPicker")
+        return .result()
+    }
+}


### PR DESCRIPTION
## Summary
- Add **Start Walk** and **Start Run** complications that allow users to quickly start workouts directly from the watch face
- Tapping a complication opens a quick indoor/outdoor picker, then the workout starts immediately
- After ending a workout, the app automatically returns to the dashboard view

## Changes
- **New complications**: `StartWalkComplication` (green, figure.walk) and `StartRunComplication` (orange, figure.run)
- **QuickStartEnvironmentPicker**: Minimal 2-button picker for indoor/outdoor selection
- **QuickStartState**: Observable state manager for handling deep links from complications
- **URL scheme**: Registered `stepsync://` URL scheme in Watch app for deep linking
- **Navigation improvements**: Auto-navigate to workout view on start, return to dashboard on end

## Supported Complication Families
- Circular
- Rectangular
- Inline
- Corner

## Test plan
- [ ] Deploy to physical Apple Watch
- [ ] Add "Start Walk" complication to watch face
- [ ] Tap complication → verify indoor/outdoor picker appears
- [ ] Select "Outdoor" → verify workout starts and workout view is displayed
- [ ] End workout → verify app returns to dashboard
- [ ] Repeat test with "Start Run" complication
- [ ] Test all 4 complication sizes on different watch faces

🤖 Generated with [Claude Code](https://claude.com/claude-code)